### PR TITLE
added a new g-link component to make links focusable on firefox

### DIFF
--- a/components/global/g-link.vue
+++ b/components/global/g-link.vue
@@ -2,10 +2,9 @@
   <nuxt-link
     tabindex="-1"
     role="link"
-    exact
+    :exact="props.exact"
     :to="props.to"
-    :class="[data.staticClass]"
-    
+    :class="[data.staticClass, data.class]"
   >
     <button class="g-link">
       <slot></slot>
@@ -16,7 +15,8 @@
 <script>
 export default {
   props: {
-    to: [String, Object]
+    to: [String, Object],
+    exact: Boolean,
   }
 }
 </script>
@@ -25,7 +25,6 @@ export default {
 .g-link {
   font: inherit;
   padding: 4px;
-  // font-size: 1.125rem;
   outline: none;
   background: transparent;
   border: 1px solid transparent;

--- a/components/global/g-link.vue
+++ b/components/global/g-link.vue
@@ -1,0 +1,48 @@
+<template functional>
+  <nuxt-link
+    tabindex="-1"
+    role="link"
+    exact
+    :to="props.to"
+    :class="[data.staticClass]"
+    
+  >
+    <button class="g-link">
+      <slot></slot>
+    </button>
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  props: {
+    to: [String, Object]
+  }
+}
+</script>
+
+<style lang="scss" >
+.g-link {
+  font: inherit;
+  padding: 4px;
+  // font-size: 1.125rem;
+  outline: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  &:focus,
+  &:hover {
+    background: #0001;
+  }
+}
+
+.nuxt-link-active,
+.nuxt-link-exact-active {
+  .g-link {
+    text-decoration-line: underline;
+    text-decoration-thickness: 2px;
+    text-decoration-color: #03a59d;
+  }
+}
+</style>

--- a/components/global/index.js
+++ b/components/global/index.js
@@ -1,7 +1,9 @@
 import GInput from './g-input'
+import GLink from './g-link'
 
 export default {
   install(Vue) {
     Vue.component('GInput', GInput)
+    Vue.component('GLink', GLink)
   }
 }

--- a/components/the-navbar.vue
+++ b/components/the-navbar.vue
@@ -8,8 +8,8 @@
               <nuxt-link exact class="navlink" to="/">Landlord Lookup</nuxt-link>
             </section>
             <section class="links">
-              <g-link class="navlink" to="/">Home</g-link>
-              <g-link class="navlink" to="/about">About</g-link>
+              <g-link exact class="navlink" to="/">Home</g-link>
+              <g-link exact class="navlink" to="/about">About</g-link>
             </section>
           </nav>
         </div>

--- a/components/the-navbar.vue
+++ b/components/the-navbar.vue
@@ -8,8 +8,8 @@
               <nuxt-link exact class="navlink" to="/">Landlord Lookup</nuxt-link>
             </section>
             <section class="links">
-              <nuxt-link class="navlink" exact to="/">Home</nuxt-link>
-              <nuxt-link class="navlink" exact to="/about">About</nuxt-link>
+              <g-link class="navlink" to="/">Home</g-link>
+              <g-link class="navlink" to="/about">About</g-link>
             </section>
           </nav>
         </div>
@@ -46,7 +46,6 @@ export default {
     }
     .links {
       .navlink {
-        margin-left: .5rem;
         font-size: 1.125rem;
       }
     }


### PR DESCRIPTION
This PR adds a new `<GLink />` component that allows links to keyboard focusable on Firefox.

`<a>` elements appear to not be keyboard focusable in Firefox.

`<button>` elements are keyboard focusable in Firefox.
 
`<GLink />` wraps a `button` with `nuxt-link` (itself, a wrapper around `<a>`). 